### PR TITLE
Make Plaid class not final

### DIFF
--- a/src/Plaid.php
+++ b/src/Plaid.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\ResponseInterface;
 use Shuttle\Shuttle;
 use TomorrowIdeas\Plaid\Entities\Address;
 
-final class Plaid
+class Plaid
 {
 	/**
 	 * Plaid API host environment.


### PR DESCRIPTION
Currently `Plaid` class is marked as final, there is no real benefits to this, and for the downside it makes testing hard as i can't just mock this object.