### PR TITLE
Adding support for transactions refresh endpoint

### DIFF
--- a/src/Plaid.php
+++ b/src/Plaid.php
@@ -1014,4 +1014,21 @@ class Plaid
 			$this->buildRequest("post", "payment_initiation/payment/list", $this->clientCredentials($params))
 		);
 	}
+
+	/**
+	 * Send a refresh request for given item.
+	 *
+	 * @param string $access_token
+	 * @return object
+	 */
+	public function requestTransactionsRefresh(string $access_token): object
+	{
+		$params = [
+			"access_token" => $access_token,
+		];
+
+		return $this->doRequest(
+			$this->buildRequest("post", "transactions/refresh", $this->clientCredentials($params))
+		);
+	}
 }

--- a/src/Plaid.php
+++ b/src/Plaid.php
@@ -1021,7 +1021,7 @@ class Plaid
 	 * @param string $access_token
 	 * @return object
 	 */
-	public function requestTransactionsRefresh(string $access_token): object
+	public function refreshTransactions(string $access_token): object
 	{
 		$params = [
 			"access_token" => $access_token,

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -27,7 +27,7 @@ class TransactionTest extends TestCase
 
     public function test_transaction_refresh()
     {
-        $response = $this->getPlaidClient()->requestTransactionsRefresh("access_token");
+        $response = $this->getPlaidClient()->refreshTransactions("access_token");
 
         $this->assertEquals("POST", $response->method);
         $this->assertEquals("2019-05-29", $response->version);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -24,4 +24,17 @@ class TransactionTest extends TestCase
         $this->assertEquals("2019-03-31", $response->params->end_date);
         $this->assertEquals(new \StdClass, $response->params->options);
     }
+
+    public function test_transaction_refresh()
+    {
+        $response = $this->getPlaidClient()->requestTransactionsRefresh("access_token");
+
+        $this->assertEquals("POST", $response->method);
+        $this->assertEquals("2019-05-29", $response->version);
+        $this->assertEquals("application/json", $response->content);
+        $this->assertEquals("/transactions/refresh", $response->path);
+        $this->assertEquals("client_id", $response->params->client_id);
+        $this->assertEquals("secret", $response->params->secret);
+        $this->assertEquals("access_token", $response->params->access_token);
+    }
 }


### PR DESCRIPTION
This PR is intended to add support for transactions refresh feature Plaid offers. It's followed by a webhooks call with new/deleted transactions if any.

Refer to https://plaid.com/docs/api/products/#transactionsrefresh for more info.