### PR TITLE
Might need to rename this key

### DIFF
--- a/src/Entities/AccountHolder.php
+++ b/src/Entities/AccountHolder.php
@@ -31,7 +31,7 @@ class AccountHolder
 	{
 		return [
 			"legal_name" => $this->legal_name,
-			"email" => $this->email
+			"email_address" => $this->email
 		];
 	}
 }


### PR DESCRIPTION
I get this error:

```json
  #response: {#4249
    +"display_message": null
    +"documentation_url": "https://plaid.com/docs/?ref=error#invalid-request-errors"
    +"error_code": "UNKNOWN_FIELDS"
    +"error_message": "the following fields are not recognized by this endpoint: user.email"
    +"error_type": "INVALID_REQUEST"
    +"request_id": "F9q9ADTq1olrYny"
    +"suggested_action": null
  }
```

Until I did the following after looking the docs and seeing what the API anted