### PR TITLE
feat: Add `optional_products` to link token create endpoint

### DIFF
--- a/src/Resources/Tokens.php
+++ b/src/Resources/Tokens.php
@@ -25,6 +25,7 @@ class Tokens extends AbstractResource
 	 * @param string|null $payment_id
 	 * @param string|null $institution_id
 	 * @param array|null $auth
+	 * @param array|null $optional_products
 	 * @throws PlaidRequestException
 	 * @return object
 	 */
@@ -42,7 +43,8 @@ class Tokens extends AbstractResource
 		?string $android_package_name = null,
 		?string $payment_id = null,
 		?string $institution_id = null,
-		?array $auth = null): object {
+		?array $auth = null,
+		?array $optional_products = []): object {
 
 		$params = [
 			"client_name" => $client_name,
@@ -88,6 +90,10 @@ class Tokens extends AbstractResource
 
 		if ($auth) {
 			$params["auth"] = $auth;
+		}
+
+		if ($optional_products) {
+			$params["optional_products"] = $optional_products;
 		}
 
 		return $this->sendRequest(


### PR DESCRIPTION
The `/link/token/create` endpoint supports an [`optional_products` request field](https://plaid.com/docs/api/link/#link-token-create-request-optional-products). This PR adds `optional_products` as a named argument.